### PR TITLE
Combined APIs

### DIFF
--- a/pyclient/.gitignore
+++ b/pyclient/.gitignore
@@ -1,3 +1,4 @@
 psmconfig.json
 apigroups/
+psmapi/
 swagger/

--- a/pyclient/.gitignore
+++ b/pyclient/.gitignore
@@ -2,3 +2,4 @@ psmconfig.json
 apigroups/
 psmapi/
 swagger/
+*__pycache__*

--- a/pyclient/apps/cluster_ping.py
+++ b/pyclient/apps/cluster_ping.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
-from datetime import date
+
 import os
-from apigroups.cluster import ClusterV1Api
-from apigroups.cluster import configuration, api_client
+from apigroups.client.apis import ClusterV1Api
+from apigroups.client import configuration, api_client
 import warnings
 warnings.simplefilter("ignore")
 
@@ -28,7 +28,7 @@ uptime_sec = int(uptime_total_sec % 60)
 
 print("\nCluster Uptime: {}d {}h {}m {}s".format(
     uptime_days, uptime_hours, uptime_minutes, uptime_sec))
-print("Cluster Condition: ", response["status"]["conditions"][0]["type"])
+print("Cluster Condition: ", response.status.conditions[0].type)
 
 nodes_unhealthy = False
 for node in response.status.quorum_status.members:
@@ -40,10 +40,11 @@ for node in response.status.quorum_status.members:
 if not nodes_unhealthy:
     print("\n\tAll nodes are healthy\n")
 
-# response = api_instance.get_distributed_service_card("asdasd")
-
 # DSCs and health
 response = api_instance.list_distributed_service_card()
 
 for dsc in response.items:
-    print("\tDSC " + dsc.meta.name + " is " + dsc.status.conditions[0].type)
+    if "conditions" in dsc.status and len(dsc.status.conditions)>0:
+        print("\tDSC " + dsc.meta.name + " is ", dsc.status.conditions[0].type)
+    else:
+        print("\tDSC " + dsc.meta.name + " health cannot be determined.")

--- a/pyclient/apps/workload_logs.py
+++ b/pyclient/apps/workload_logs.py
@@ -1,0 +1,52 @@
+from datetime import date
+import os
+from apigroups.sysruntime import DistributedservicecardsV1Api
+from apigroups.sysruntime import configuration, api_client
+from apigroups.sysruntime import SysruntimeConnectionRequest
+from apigroups.sysruntime.client.model.api_list_watch_options import ApiListWatchOptions
+
+from apigroups.workload import WorkloadV1Api
+from apigroups.workload import api_client as w_api_client
+import warnings
+warnings.simplefilter("ignore")
+
+HOME = os.environ['HOME']
+
+configuration = configuration.Configuration(
+    psm_config_path=HOME+"/.psm/config.json",
+    interactive_mode=True
+)
+configuration.verify_ssl = False
+
+client = api_client.ApiClient(configuration)
+dsc_api = DistributedservicecardsV1Api(client)
+
+wclient = w_api_client.ApiClient(configuration)
+workload_api = WorkloadV1Api(wclient)
+
+workload_interface_ips = set()
+
+response = workload_api.get_workload('default', 'orch1--vm-48')
+for interface in response.status.interfaces:
+    ips_set = set(interface.ip_addresses)
+    workload_interface_ips.update(ips_set)
+
+print(workload_interface_ips)
+
+dscs = response.status.interfaces[0].dsc_interfaces
+for dsc in dscs:
+    body = SysruntimeConnectionRequest(dsc_name=dsc, list=ApiListWatchOptions(name="temp", max_results=50))
+    response = dsc_api.post_query_connection(dsc, body)
+    for item in response.items:
+        flow_info = item.spec.initiator_flow.flow_key.ipv4
+
+        protocol = flow_info.protocol
+        dest_ip = flow_info.destination
+        src_ip = flow_info.source
+        if protocol == 'TCP' or protocol == 'UDP':
+            src_port = flow_info.tcp_udp["source_port"] 
+            dest_port = flow_info.tcp_udp["destination_port"]
+            print("FLOW:", protocol, src_ip+":"+src_port, "to", dest_ip+":"+dest_port)
+        else:
+            print("FLOW:", protocol, src_ip, "to", dest_ip)
+        

--- a/pyclient/gen.sh
+++ b/pyclient/gen.sh
@@ -7,7 +7,7 @@ do
   str3="${str2/\//}"
   str4="${str3/svc_/}"
 
-  java -jar openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -i "$file" -p group=$str4 -c genconfig.json -g python -o apigroups/$str4
+  java -jar openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -i "$file" -p group=$str4 -c genconfig.json -g python -o psmapi/
 
   echo "$str4"
 done

--- a/pyclient/gen.sh
+++ b/pyclient/gen.sh
@@ -7,7 +7,7 @@ do
   str3="${str2/\//}"
   str4="${str3/svc_/}"
 
-  java -jar openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -i "$file" -p group=$str4 -c genconfig.json -g python -o psmapi/
+  java -jar openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -i "$file" -p group=$str4 -c genconfig.json -g python -o apigroups/
 
   echo "$str4"
 done

--- a/pyclient/genconfig.json
+++ b/pyclient/genconfig.json
@@ -1,5 +1,5 @@
 {
-    "libName": "apigroups",
+    "libName": "psmapi",
     "packageName": "client",
     "modelPackage": "model",
     "apiPackage": "api"

--- a/pyclient/genconfig.json
+++ b/pyclient/genconfig.json
@@ -1,5 +1,5 @@
 {
-    "libName": "psmapi",
+    "libName": "apigroups",
     "packageName": "client",
     "modelPackage": "model",
     "apiPackage": "api"

--- a/pyclient/getswagger.py
+++ b/pyclient/getswagger.py
@@ -10,43 +10,6 @@ HOME = os.environ["HOME"]
 psm_config_path = HOME+"/.psm/config.json"
 psm_config = {}
 
-def update_psm_config(path):
-    psmip = input("Enter PSM IP address: ")
-    with open(path, "w") as f:
-        config_data = {"psm-ip": psmip}
-        json.dump(config_data, f)
-    return config_data
-
-def get_psm_config():
-    config_data = {}
-    config_path = psm_config_path
-    if not os.path.exists(psm_config_path):
-        logging.warn("PSM config does not exist at "+ psm_config_path)
-        cont = input("Create confiig at "+psm_config_path+" ? [y/n]")
-        if cont.lower() != 'y':
-            sys.exit(1)
-            return
-        if psm_config_path[0] == "~":
-            HOME = os.environ["HOME"]
-            config_path = HOME + config_path[1:]
-        foldersplit = config_path.split(os.sep)
-        if foldersplit[-1]:
-            dirpath = (os.sep).join(foldersplit[:-1])
-            if not os.path.exists(dirpath):
-                os.makedirs((os.sep).join(foldersplit))
-            config_data = update_psm_config(config_path)
-        else:
-            logging.error("Invalid PSM config path")
-            sys.exit(1)
-    else:
-        with open(config_path, "r") as f:
-            config_data = json.load(f)
-    return config_data
-
-def write_psm_config(config_data):
-    with open(psm_config_path, "w") as f:
-        psm_config = json.dump(config_data, f)
-
 def downloadSwaggerFiles():
     host = psm_config["psm-ip"]
     if not os.path.exists("swagger"):
@@ -88,6 +51,9 @@ def processSwagger(filename, jsondata):
         del jsondata["definitions"]["apiObjectMeta"]["properties"]["name"]["pattern"]
         del jsondata["definitions"]["apiObjectMeta"]["properties"]["tenant"]["pattern"]
         del jsondata["definitions"]["apiObjectMeta"]["properties"]["namespace"]["pattern"]
+    if filename == "objstore":
+        del jsondata["paths"]["/objstore/v1/uploads/snapshots"]
+        del jsondata["paths"]["/objstore/v1/uploads/images"]
     return jsondata
 
 if __name__ == "__main__":

--- a/pyclient/getswagger.py
+++ b/pyclient/getswagger.py
@@ -4,6 +4,7 @@ import re
 import os
 import sys
 import logging
+from utils import update_psm_config, get_psm_config
 
 HOME = os.environ["HOME"]
 psm_config_path = HOME+"/.psm/config.json"

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -126,9 +126,9 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
         supportingFiles.add(new SupportingFile("model_utils.mustache", packagePath(), "model_utils.py"));
 
         // add the models and apis folders
-        supportingFiles.add(new SupportingFile("__init__models.mustache", packagePath() + File.separatorChar + "models", "__init__.py"));
+        supportingFiles.add(new SupportingFile("__init__models.mustache", packagePath() + File.separatorChar + "models", group()+".py"));
         supportingFiles.add(new SupportingFile("__init__model.mustache", packagePath() + File.separatorChar + "model", "__init__.py"));
-        supportingFiles.add(new SupportingFile("__init__apis.mustache", packagePath() + File.separatorChar + "apis", "__init__.py"));
+        supportingFiles.add(new SupportingFile("__init__apis.mustache", packagePath() + File.separatorChar + "apis", group()+".py"));
         // Generate the 'signing.py' module, but only if the 'HTTP signature' security scheme is specified in the OAS.
         Map<String, SecurityScheme> securitySchemeMap = openAPI != null ?
                 (openAPI.getComponents() != null ? openAPI.getComponents().getSecuritySchemes() : null) : null;

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -126,9 +126,14 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
         supportingFiles.add(new SupportingFile("model_utils.mustache", packagePath(), "model_utils.py"));
 
         // add the models and apis folders
-        supportingFiles.add(new SupportingFile("__init__models.mustache", packagePath() + File.separatorChar + "models", group()+".py"));
+        supportingFiles.add(new SupportingFile("models.mustache", packagePath() + File.separatorChar + "models/"+group(), "__init__.py"));
+        supportingFiles.add(new SupportingFile("__init__models.mustache", packagePath() + File.separatorChar + "models", "__init__.py"));
+
         supportingFiles.add(new SupportingFile("__init__model.mustache", packagePath() + File.separatorChar + "model", "__init__.py"));
-        supportingFiles.add(new SupportingFile("__init__apis.mustache", packagePath() + File.separatorChar + "apis", group()+".py"));
+
+        supportingFiles.add(new SupportingFile("apis.mustache", packagePath() + File.separatorChar + "apis/"+group(), "__init__.py"));
+
+        supportingFiles.add(new SupportingFile("__init__apis.mustache", packagePath() + File.separatorChar + "apis/", "__init__.py"));
         // Generate the 'signing.py' module, but only if the 'HTTP signature' security scheme is specified in the OAS.
         Map<String, SecurityScheme> securitySchemeMap = openAPI != null ?
                 (openAPI.getComponents() != null ? openAPI.getComponents().getSecuritySchemes() : null) : null;
@@ -317,7 +322,7 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
     @Override
     public String toModelImport(String name) {
         // name looks like Cat
-        return "from " + libName() + "." + group() + "." + modelPackage() + "." + toModelFilename(name) + " import " + toModelName(name);
+        return "from " + libName() + "." + modelPackage() + "." + toModelFilename(name) + " import " + toModelName(name);
     }
 
     @Override

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__.mustache
@@ -1,3 +1,3 @@
-from {{libName}}.{{group}}.{{packageName}} import *
-from {{libName}}.{{group}}.{{packageName}}.models import *
-from {{libName}}.{{group}}.{{packageName}}.apis import *
+from {{libName}}.{{packageName}} import *
+from {{libName}}.{{packageName}}.models import *
+from {{libName}}.{{packageName}}.apis import *

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__apis.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__apis.mustache
@@ -1,23 +1,17 @@
-{{#apiInfo}}
-{{#apis}}
-{{#-first}}
+import importlib
+import os
 
-# flake8: noqa
+from os import listdir
+from os.path import isfile, join
 
-# Import all APIs into this package.
-# If you have many APIs here with many many models used in each API this may
-# raise a `RecursionError`.
-# In order to avoid this, import only the API that you directly need like:
-#
-#   from {{packagename}}.api.{{classVarName}} import {{classname}}
-#
-# or import this package, but before doing it, use:
-#
-#   import sys
-#   sys.setrecursionlimit(n)
+ownpath = __file__.replace("__init__.py", "")
 
-# Import APIs into API package:
-{{/-first}}
-from {{libName}}.{{packageName}}.{{apiPackage}}.{{classVarName}} import {{classname}}
-{{/apis}}
-{{/apiInfo}}
+__all__ = [ name for name in os.listdir(ownpath) if (os.path.isdir(os.path.join(ownpath, name)) and not name.startswith("_")) ]
+
+for i in __all__:
+    module = importlib.import_module('.'+i, "{{libName}}.{{packageName}}.apis")
+    globals().update(
+        {n: getattr(module, n) for n in module.__all__} if hasattr(module, '__all__') 
+        else 
+        {k: v for (k, v) in module.__dict__.items() if not k.startswith('_')
+    })

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__apis.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__apis.mustache
@@ -18,6 +18,6 @@
 
 # Import APIs into API package:
 {{/-first}}
-from {{libName}}.{{group}}.{{packageName}}.{{apiPackage}}.{{classVarName}} import {{classname}}
+from {{libName}}.{{packageName}}.{{apiPackage}}.{{classVarName}} import {{classname}}
 {{/apis}}
 {{/apiInfo}}

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__models.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__models.mustache
@@ -11,6 +11,6 @@
 
 {{#models}}
 {{#model}}
-from {{libName}}.{{group}}.{{modelPackage}}.{{classFilename}} import {{classname}}
+from {{libName}}.{{modelPackage}}.{{classFilename}} import {{classname}}
 {{/model}}
 {{/models}}

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__models.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__models.mustache
@@ -9,8 +9,20 @@
 # import sys
 # sys.setrecursionlimit(n)
 
-{{#models}}
-{{#model}}
-from {{libName}}.{{modelPackage}}.{{classFilename}} import {{classname}}
-{{/model}}
-{{/models}}
+import importlib
+import os
+
+from os import listdir
+from os.path import isfile, join
+
+ownpath = __file__.replace("__init__.py", "")
+
+__all__ = [ name for name in os.listdir(ownpath) if (os.path.isdir(os.path.join(ownpath, name)) and not name.startswith("_")) ]
+
+for i in __all__:
+    module = importlib.import_module('.'+i, "{{libName}}.{{packageName}}.models")
+    globals().update(
+        {n: getattr(module, n) for n in module.__all__} if hasattr(module, '__all__') 
+        else 
+        {k: v for (k, v) in module.__dict__.items() if not k.startswith('_')
+    })

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__package.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/__init__package.mustache
@@ -5,21 +5,21 @@
 __version__ = "{{packageVersion}}"
 
 # import ApiClient
-from {{libName}}.{{group}}.{{packageName}}.api_client import ApiClient
+from {{libName}}.{{packageName}}.api_client import ApiClient
 
 # import Configuration
-from {{libName}}.{{group}}.{{packageName}}.configuration import Configuration
+from {{libName}}.{{packageName}}.configuration import Configuration
 {{#hasHttpSignatureMethods}}
-from {{libName}}.{{group}}.{{packageName}}.signing import HttpSigningConfiguration
+from {{libName}}.{{packageName}}.signing import HttpSigningConfiguration
 {{/hasHttpSignatureMethods}}
 
 # import exceptions
-from {{libName}}.{{group}}.{{packageName}}.exceptions import OpenApiException
-from {{libName}}.{{group}}.{{packageName}}.exceptions import ApiAttributeError
-from {{libName}}.{{group}}.{{packageName}}.exceptions import ApiTypeError
-from {{libName}}.{{group}}.{{packageName}}.exceptions import ApiValueError
-from {{libName}}.{{group}}.{{packageName}}.exceptions import ApiKeyError
-from {{libName}}.{{group}}.{{packageName}}.exceptions import ApiException
+from {{libName}}.{{packageName}}.exceptions import OpenApiException
+from {{libName}}.{{packageName}}.exceptions import ApiAttributeError
+from {{libName}}.{{packageName}}.exceptions import ApiTypeError
+from {{libName}}.{{packageName}}.exceptions import ApiValueError
+from {{libName}}.{{packageName}}.exceptions import ApiKeyError
+from {{libName}}.{{packageName}}.exceptions import ApiException
 {{#recursionLimit}}
 
 __import__('sys').setrecursionlimit({{{.}}})

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -3,8 +3,8 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from {{libName}}.{{group}}.{{packageName}}.api_client import ApiClient, Endpoint as _Endpoint
-from {{libName}}.{{group}}.{{packageName}}.model_utils import (  # noqa: F401
+from {{libName}}.{{packageName}}.api_client import ApiClient, Endpoint as _Endpoint
+from {{libName}}.{{packageName}}.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
     date,
@@ -13,7 +13,7 @@ from {{libName}}.{{group}}.{{packageName}}.model_utils import (  # noqa: F401
     none_type,
     validate_and_convert_types
 )
-import {{libName}}.{{group}}.{{packageName}} as {{packageName}}
+import {{libName}}.{{packageName}} as {{packageName}}
 {{#imports}}
 {{{import}}}
 {{/imports}}

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -16,10 +16,10 @@ from urllib3.fields import RequestField
 import tornado.gen
 {{/tornado}}
 
-from {{libName}}.{{group}}.{{packageName}} import rest
-from {{libName}}.{{group}}.{{packageName}}.configuration import Configuration
-from {{libName}}.{{group}}.{{packageName}}.exceptions import ApiTypeError, ApiValueError, ApiException
-from {{libName}}.{{group}}.{{packageName}}.model_utils import (
+from {{libName}}.{{packageName}} import rest
+from {{libName}}.{{packageName}}.configuration import Configuration
+from {{libName}}.{{packageName}}.exceptions import ApiTypeError, ApiValueError, ApiException
+from {{libName}}.{{packageName}}.model_utils import (
     ModelNormal,
     ModelSimple,
     ModelComposed,

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/apis.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/apis.mustache
@@ -1,0 +1,23 @@
+{{#apiInfo}}
+{{#apis}}
+{{#-first}}
+
+# flake8: noqa
+
+# Import all APIs into this package.
+# If you have many APIs here with many many models used in each API this may
+# raise a `RecursionError`.
+# In order to avoid this, import only the API that you directly need like:
+#
+#   from {{packagename}}.api.{{classVarName}} import {{classname}}
+#
+# or import this package, but before doing it, use:
+#
+#   import sys
+#   sys.setrecursionlimit(n)
+
+# Import APIs into API package:
+{{/-first}}
+from {{libName}}.{{packageName}}.{{apiPackage}}.{{classVarName}} import {{classname}}
+{{/apis}}
+{{/apiInfo}}

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -14,7 +14,7 @@ import json
 import getpass
 
 from http import client as http_client
-from {{libName}}.{{group}}.{{packageName}}.exceptions import ApiValueError
+from {{libName}}.{{packageName}}.exceptions import ApiValueError
 
 
 JSON_SCHEMA_VALIDATION_KEYWORDS = {

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -12,6 +12,7 @@ import os
 import sys
 import json
 import getpass
+from utils import update_psm_config, get_psm_config, write_psm_config
 
 from http import client as http_client
 from {{libName}}.{{packageName}}.exceptions import ApiValueError
@@ -191,11 +192,11 @@ conf = {{{packageName}}}.Configuration(
 
         self.cookie = None
         self.psm_config_path = psm_config_path
-        self.psm_config = self.get_psm_config()
+        self.psm_config = get_psm_config()
         if "psm-ip" not in self.psm_config:
             logging.error("'psm-ip' not set in PSM config file.")
             if self.interactive_mode:
-                self.psm_config = self.update_psm_config(this.psm_config)
+                self.psm_config = update_psm_config(this.psm_config)
         
         self.debugMode = False
         if ("debug" in self.psm_config and self.psm_config["debug"] == "true") or debugMode:
@@ -666,44 +667,6 @@ conf = {{{packageName}}}.Configuration(
         """Fix base path."""
         self._base_path = value
         self.server_index = None
-
-    def update_psm_config(self, path):
-        psmip = input("Enter PSM IP address:")
-        with open(path, "w") as f:
-            data = {"psmip": psmip}
-            json.dump(data, f)
-        return data
-
-    def get_psm_config(self):
-        configpath = self.psm_config_path
-        if not os.path.exists(self.psm_config_path):
-            logging.error("PSM config does not exist at "+ self.psm_config_path)
-            if self.interactive_mode:
-                cont = input("Create config at "+self.psm_config_path+" ? [y/n]")
-                if cont.lower() != 'y':
-                    sys.exit(1)
-                    return
-            else:
-                sys.exit(1)
-            if self.psm_config_path[0] == "~":
-                HOME = os.environ["HOME"]
-                configpath = HOME + configpath[1:]
-            foldersplit = configpath.split(os.sep)
-            if foldersplit[-1] and self.interactive_mode:
-                os.makedirs(foldersplit[:-1].join(os.sep))
-                data = self.update_psm_config(configpath)
-                return data
-            else:
-                logging.error("Invalid PSM config path")
-                sys.exit(1)
-        else:
-            with open(configpath, "r") as f:
-                psm_config = json.load(f)
-        return psm_config
-    
-    def write_psm_config(self, data):
-        with open(self.psm_config_path, "w") as f:
-            psm_config = json.dump(data, f)
     
     def login(self):
         loginpath = self._base_path+"/v1/login"
@@ -725,7 +688,7 @@ conf = {{{packageName}}}.Configuration(
         resp_cookie = response.cookies.items()[0]
         cookie = resp_cookie[0] + "=" + resp_cookie[1]
         self.cookie = cookie
-        psm_config = self.get_psm_config()
+        psm_config = get_psm_config()
         psm_config["token"] = self.cookie
-        self.write_psm_config(psm_config)
+        write_psm_config(self.psm_config_path, psm_config)
         return cookie

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/model.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/model.mustache
@@ -5,7 +5,7 @@ import sys  # noqa: F401
 
 import nulltype  # noqa: F401
 
-from {{libName}}.{{group}}.{{packageName}}.model_utils import (  # noqa: F401
+from {{libName}}.{{packageName}}.model_utils import (  # noqa: F401
     ApiTypeError,
     ModelComposed,
     ModelNormal,

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/model_utils.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/model_utils.mustache
@@ -10,7 +10,7 @@ import tempfile
 
 from dateutil.parser import parse
 
-from {{libName}}.{{group}}.{{packageName}}.exceptions import (
+from {{libName}}.{{packageName}}.exceptions import (
     ApiKeyError,
     ApiAttributeError,
     ApiTypeError,

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/models.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/models.mustache
@@ -1,0 +1,16 @@
+# flake8: noqa
+
+# import all models into this package
+# if you have many models here with many references from one model to another this may
+# raise a RecursionError
+# to avoid this, import only the models that you directly need like:
+# from from {{modelPackage}}.pet import Pet
+# or import this package, but before doing it, use:
+# import sys
+# sys.setrecursionlimit(n)
+
+{{#models}}
+{{#model}}
+from {{libName}}.{{modelPackage}}.{{classFilename}} import {{classname}}
+{{/model}}
+{{/models}}

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/python_doc_auth_partial.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/python_doc_auth_partial.mustache
@@ -1,6 +1,6 @@
 # Defining the host is optional and defaults to {{{basePath}}}
 # See configuration.py for a list of all supported configuration parameters.
-configuration = {{libName}}.{{group}}.{{{packageName}}}.Configuration(
+configuration = {{libName}}.{{{packageName}}}.Configuration(
     psm_config_path=HOME+"/.psm/config.json"
 )
 configuration.verify_ssl = False
@@ -15,7 +15,7 @@ configuration.verify_ssl = False
 {{#isBasicBasic}}
 
 # Configure HTTP basic authorization: {{{name}}}
-configuration = {{libName}}.{{group}}.{{{packageName}}}.Configuration(
+configuration = {{libName}}.{{{packageName}}}.Configuration(
     username = 'YOUR_USERNAME',
     password = 'YOUR_PASSWORD'
 )
@@ -23,7 +23,7 @@ configuration = {{libName}}.{{group}}.{{{packageName}}}.Configuration(
 {{#isBasicBearer}}
 
 # Configure Bearer authorization{{#bearerFormat}} ({{{.}}}){{/bearerFormat}}: {{{name}}}
-configuration = {{libName}}.{{group}}.{{{packageName}}}.Configuration(
+configuration = {{libName}}.{{{packageName}}}.Configuration(
     access_token = 'YOUR_BEARER_TOKEN'
 )
 {{/isBasicBearer}}
@@ -65,22 +65,22 @@ configuration = {{libName}}.{{group}}.{{{packageName}}}.Configuration(
 # the API server.
 #
 # See {{{packageName}}}.signing for a list of all supported parameters.
-configuration = {{libName}}.{{group}}.{{{packageName}}}.Configuration(
+configuration = {{libName}}.{{{packageName}}}.Configuration(
     host = "{{{basePath}}}",
-    signing_info = {{libName}}.{{group}}.{{{packageName}}}.signing.HttpSigningConfiguration(
+    signing_info = {{libName}}.{{{packageName}}}.signing.HttpSigningConfiguration(
         key_id = 'my-key-id',
         private_key_path = 'private_key.pem',
         private_key_passphrase = 'YOUR_PASSPHRASE',
-        signing_scheme = {{libName}}.{{group}}.{{{packageName}}}.signing.SCHEME_HS2019,
-        signing_algorithm = {{libName}}.{{group}}.{{{packageName}}}.signing.ALGORITHM_ECDSA_MODE_FIPS_186_3,
-        hash_algorithm = {{libName}}.{{group}}.{{{packageName}}}.signing.SCHEME_RSA_SHA256,
+        signing_scheme = {{libName}}.{{{packageName}}}.signing.SCHEME_HS2019,
+        signing_algorithm = {{libName}}.{{{packageName}}}.signing.ALGORITHM_ECDSA_MODE_FIPS_186_3,
+        hash_algorithm = {{libName}}.{{{packageName}}}.signing.SCHEME_RSA_SHA256,
         signed_headers = [
-                            {{libName}}.{{group}}.{{{packageName}}}.signing.HEADER_REQUEST_TARGET,
-                            {{libName}}.{{group}}.{{{packageName}}}.signing.HEADER_CREATED,
-                            {{libName}}.{{group}}.{{{packageName}}}.signing.HEADER_EXPIRES,
-                            {{libName}}.{{group}}.{{{packageName}}}.signing.HEADER_HOST,
-                            {{libName}}.{{group}}.{{{packageName}}}.signing.HEADER_DATE,
-                            {{libName}}.{{group}}.{{{packageName}}}.signing.HEADER_DIGEST,
+                            {{libName}}.{{{packageName}}}.signing.HEADER_REQUEST_TARGET,
+                            {{libName}}.{{{packageName}}}.signing.HEADER_CREATED,
+                            {{libName}}.{{{packageName}}}.signing.HEADER_EXPIRES,
+                            {{libName}}.{{{packageName}}}.signing.HEADER_HOST,
+                            {{libName}}.{{{packageName}}}.signing.HEADER_DATE,
+                            {{libName}}.{{{packageName}}}.signing.HEADER_DIGEST,
                             'Content-Type',
                             'Content-Length',
                             'User-Agent'
@@ -101,7 +101,7 @@ configuration.api_key['{{{name}}}'] = 'YOUR_API_KEY'
 {{#isOAuth}}
 
 # Configure OAuth2 access token for authorization: {{{name}}}
-configuration = {{libName}}.{{group}}.{{{packageName}}}.Configuration(
+configuration = {{libName}}.{{{packageName}}}.Configuration(
     host = "{{{basePath}}}"
 )
 configuration.access_token = 'YOUR_ACCESS_TOKEN'

--- a/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/pyclient/openapi-generator/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 
 import urllib3
 
-from {{libName}}.{{group}}.{{packageName}}.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
+from {{libName}}.{{packageName}}.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
 
 
 logger = logging.getLogger(__name__)

--- a/pyclient/utils/__init__.py
+++ b/pyclient/utils/__init__.py
@@ -1,0 +1,1 @@
+from .login import *

--- a/pyclient/utils/login.py
+++ b/pyclient/utils/login.py
@@ -1,0 +1,45 @@
+import os
+import logging
+import sys
+import json
+
+def get_psm_config():
+    HOME = os.environ["HOME"]
+    psm_config_path = HOME+"/.psm/config.json"
+
+    config_data = {}
+    config_path = psm_config_path
+    if not os.path.exists(psm_config_path):
+        logging.warn("PSM config does not exist at "+ psm_config_path)
+        cont = input("Create config at "+psm_config_path+" ? [y/n]")
+        if cont.lower() != 'y':
+            sys.exit(1)
+
+        if psm_config_path[0] == "~":
+            HOME = os.environ["HOME"]
+            config_path = HOME + config_path[1:]
+        foldersplit = config_path.split(os.sep)
+        if foldersplit[-1]:
+            dirpath = (os.sep).join(foldersplit[:-1])
+            if not os.path.exists(dirpath):
+                os.makedirs((os.sep).join(foldersplit))
+            config_data = update_psm_config(config_path)
+        else:
+            logging.error("Invalid PSM config path")
+            sys.exit(1)
+    else:
+        with open(config_path, "r") as f:
+            config_data = json.load(f)
+    return config_data
+
+def update_psm_config(path):
+    psmip = input("Enter PSM IP address: ")
+    with open(path, "w") as f:
+        config_data = {"psm-ip": psmip}
+        json.dump(config_data, f)
+    return config_data
+
+def write_psm_config(config_path, config_data):
+    with open(config_path, "w") as f:
+        psm_config = json.dump(config_data, f)
+    return


### PR DESCRIPTION
* All apigroups combined under one directory
* Objects can be imported as 
```from apigroups.client.models import ApiObjectMeta```
* OpenAPI generator does not support "file" type, Objstore has two endpoints which use this type, these are currently removed during swagger processing.
* Login related code moved out to `utils` directory