### PR TITLE
Pyclient Image 0.2

### DIFF
--- a/pyclient/Makefile
+++ b/pyclient/Makefile
@@ -1,4 +1,12 @@
+
+REGISTRY_URL ?= registry.test.pensando.io:5000
+PYCLIENT_CONTAINER ?= pyclient:0.2
+
 default:
+	make getswagger
+	make genclient
+
+e2e:
 	make getswagger
 	make build-generator
 	make genclient
@@ -15,7 +23,10 @@ build-generator:
 	mv openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar bin/openapi-generator-cli.jar
 
 tests:
-	cd utils && python3 test_apps.py 
+	cd utils && python3 test_apps.py
 
 clean:
 	find ./apigroups -mindepth 1 ! -regex '^./apigroups/test/.*' -delete
+
+run-container:
+	docker run -it -v ~/.psm:/root/.psm -v `pwd`:/pyclient ${REGISTRY_URL}/${PYCLIENT_CONTAINER} /bin/bash

--- a/pyclient/Makefile
+++ b/pyclient/Makefile
@@ -10,6 +10,7 @@ e2e:
 	make getswagger
 	make build-generator
 	make genclient
+	make tests
 
 getswagger:
 	python3 getswagger.py

--- a/pyclient/README.md
+++ b/pyclient/README.md
@@ -8,10 +8,13 @@ cd psm-tools/pyclient
 
 2. Run the python3 environment to make client libraries
 ```
-# docker run -it -v ~/.psm:/root/.psm -v `pwd`:/pyclient pensando/pyclient:0.1 /bin/bash
-docker run -it -v ~/.psm:/root/.psm -v `pwd`:/pyclient registry.test.pensando.io:5000/pyclient:0.1 /bin/bash
+make run-container
+```
 
-make
+
+Inside the container run `make` to generate the api client.
+```
+root@6de26ac2cb83:/pyclient# make
 ```
 
 3. Run python client apps to confirm all is good


### PR DESCRIPTION
* Added `make run-container` target
* Modified README.md to use make run-container (now pyclient version is only specified in one place)
* `make default` only fetches swagger files and generates code
* `make e2e` does a fresh start, including the build generation